### PR TITLE
Add application/json as acceptable response type for documents

### DIFF
--- a/FileGetContentsLoader.php
+++ b/FileGetContentsLoader.php
@@ -39,12 +39,12 @@ class FileGetContentsLoader
                 array(
                     'http' => array(
                       'method'  => 'GET',
-                      'header'  => "Accept: application/ld+json\r\n",
+                      'header'  => "Accept: application/ld+json, application/json; q=0.9\r\n",
                       'timeout' => Processor::REMOTE_TIMEOUT,
                     ),
                     'https' => array(
                       'method'  => 'GET',
-                      'header'  => "Accept: application/ld+json\r\n",
+                      'header'  => "Accept: application/ld+json, application/json; q=0.9\r\n",
                       'timeout' => Processor::REMOTE_TIMEOUT,
                     )
                 )


### PR DESCRIPTION
Not all servers are configured to return JSON-LD as application/ld+json, so requests
which only accept application/ld+json will fail with a 406 error response. Adding
application/json as an acceptable response will increase the likelyhood a request
will succeed.
