### PR TITLE
Fix expansion failure with external context (closes #55)

### DIFF
--- a/Processor.php
+++ b/Processor.php
@@ -1750,7 +1750,11 @@ class Processor
                     }
                 }
             } elseif (is_string($context)) {
-                $remoteContext = (string) $activectx['@base']->resolve($context);
+                if (isset($activectx['@base']) && is_object($activectx['@base'])) {
+                    $remoteContext = (string) $activectx['@base']->resolve($context);
+                } else {
+                    $remoteContext = $context;
+                }
                 if (in_array($remoteContext, $remotectxs)) {
                     throw new JsonLdException(
                         JsonLdException::RECURSIVE_CONTEXT_INCLUSION,


### PR DESCRIPTION
Allows to expand graphs like {"@vocab": "http://schema.org", "name": "foo"}