### PR TITLE
Fix for linebreaks in NQuads parser

### DIFF
--- a/NQuads.php
+++ b/NQuads.php
@@ -86,7 +86,7 @@ class NQuads implements QuadSerializerInterface, QuadParserInterface
         $graph = "$ws+(?:$iri|$bnode)";
 
         // full regexes
-        $eoln = '/(?:(\r\n)|[\n|\r])/';
+        $eoln = '/(?:(\r\n)|[\n\r])/';
         $quadRegex = "/^$ws*$subject$property$object$graph?$ws*.$ws*$/";
         $ignoreRegex = "/^$ws*(?:$comment)?$/";
 


### PR DESCRIPTION
There was a bug in the NQuads parser's end-of-line Regex which would treat the pipe symbol (|) as a linebreak; this issue causes problems when this symbol is part of a string literal because it will split and thus invalidate the whole quad and cause an error. This PR fixes that.