### PR TITLE
Add utility functions to treat JSON as JSON-LD

### DIFF
--- a/FileGetContentsLoader.php
+++ b/FileGetContentsLoader.php
@@ -32,7 +32,8 @@ class FileGetContentsLoader implements DocumentLoaderInterface
             $streamContextOptions = array(
               'method'  => 'GET',
               'header'  => "Accept: application/ld+json, application/json; q=0.9, */*; q=0.1\r\n",
-              'timeout' => Processor::REMOTE_TIMEOUT
+              'timeout' => Processor::REMOTE_TIMEOUT,
+              'ssl' => [ 'verify_peer' => true, 'verify_peer_name' => true, 'allow_self_signed'=> false ]
             );
 
             $context = stream_context_create(array(

--- a/NQuads.php
+++ b/NQuads.php
@@ -41,7 +41,8 @@ class NQuads implements QuadSerializerInterface, QuadParserInterface
                     ? $quad->getObject()
                     : '<' . $quad->getObject() . '>';
             } else {
-                $result .= '"' . $quad->getObject()->getValue() . '"';
+                // Fix F. Michel 2017-12-05. Characters " in JSON strings must be escaped.
+                $result .= '"' . str_replace ( '"', '\"', $quad->getObject()->getValue() ). '"';
                 $result .= ($quad->getObject() instanceof TypedValue)
                     ? (RdfConstants::XSD_STRING === $quad->getObject()->getType())
                         ? ''


### PR DESCRIPTION
Hi Markus,

Here is a proposition for to extension functions: expandJsonAsJson and compactJsonAsJsonLD. Both apply a JSON-LD profile to a regular JSON file. 
One thing still lacks I would say: interpret JSON as JSON-LD using the Link http header as described in the [specifcation](https://json-ld.org/spec/latest/json-ld/#interpreting-json-as-json-ld)

Also added a utility function to convert a previously expanded document to RDF quads.

Cheers,
   Franck.