### PR TITLE
Escape double-quotes and "\n" in JSON strings

### DIFF
--- a/NQuads.php
+++ b/NQuads.php
@@ -41,7 +41,10 @@ class NQuads implements QuadSerializerInterface, QuadParserInterface
                     ? $quad->getObject()
                     : '<' . $quad->getObject() . '>';
             } else {
-                $result .= '"' . $quad->getObject()->getValue() . '"';
+                // Escape double-quotes and "\n" in JSON strings
+                $search = array("\n", '"');
+                $replace = array('\n', '\"');
+                $result .= '"' . str_replace($search, $replace, $quad->getObject()->getValue()) . '"';
                 $result .= ($quad->getObject() instanceof TypedValue)
                     ? (RdfConstants::XSD_STRING === $quad->getObject()->getType())
                         ? ''


### PR DESCRIPTION
The second PR.
Cheers,
   Franck.