### PR TITLE
Added support for the 'Link' header for content negotiation.

### DIFF
--- a/FileGetContentsLoader.php
+++ b/FileGetContentsLoader.php
@@ -141,7 +141,7 @@ class FileGetContentsLoader implements DocumentLoaderInterface
      * 
      * @return array  $links  A structured array of Link header data
      */
-    protected function parseLinkHeaders(array $headers, IRI $baseIri)
+    public function parseLinkHeaders(array $headers, IRI $baseIri)
     {
         $links = array();
 

--- a/FileGetContentsLoader.php
+++ b/FileGetContentsLoader.php
@@ -112,9 +112,18 @@ class FileGetContentsLoader implements DocumentLoaderInterface
                             && ($link['rel'] === 'alternate') && ($link['type'] === 'application/ld+json'));
                     });
 
-                    if (count($altLinkHeaders) && $altLinkHeaders[0]['uri']) {
+                    // The spec states 'A response MUST NOT contain more than one HTTP Link Header
+                    // using the alternate link relation with type="application/ld+json"'
+                    if (count($altLinkHeaders) === 1) {
                         return $this->loadDocument($altLinkHeaders[0]['uri']);
-                    } elseif (('application/json' !== $remoteDocument->mediaType) && 
+                    } elseif(count($altLinkHeaders > 1)) {
+                        throw new JsonLdException(
+                            JsonLdException::LOADING_DOCUMENT_FAILED,
+                            'Received multiple alternate link headers'
+                        );
+                    } 
+
+                    if (('application/json' !== $remoteDocument->mediaType) && 
                         (0 !== substr_compare($remoteDocument->mediaType, '+json', -5))) {
                         throw new JsonLdException(
                             JsonLdException::LOADING_DOCUMENT_FAILED,

--- a/FileGetContentsLoader.php
+++ b/FileGetContentsLoader.php
@@ -139,7 +139,7 @@ class FileGetContentsLoader implements DocumentLoaderInterface
      * @param  array  $headers  An array of HTTP Link headers
      * @param  IRI  $baseIri The document's URL (used to expand relative URLs to absolutes)
      * 
-     * @return string|null an application/ld+json URI (if available) 
+     * @return array  $links  A structured array of Link header data
      */
     protected function parseLinkHeaders(array $headers, IRI $baseIri)
     {

--- a/FileGetContentsLoader.php
+++ b/FileGetContentsLoader.php
@@ -27,95 +27,134 @@ class FileGetContentsLoader implements DocumentLoaderInterface
         // if input looks like a file, try to retrieve it
         $input = trim($url);
         if (false === (isset($input[0]) && ("{" === $input[0]) || ("[" === $input[0]))) {
-            $remoteDocument = new RemoteDocument($url);
-
-            $streamContextOptions = array(
-              'method'  => 'GET',
-              'header'  => "Accept: application/ld+json, application/json; q=0.9, */*; q=0.1\r\n"
-                           . "User-Agent: lanthaler JsonLD\r\n",
-              'timeout' => Processor::REMOTE_TIMEOUT
-            );
-
-            $context = stream_context_create(array(
-                'http' => $streamContextOptions,
-                'https' => $streamContextOptions
-            ));
-
-            $httpHeadersOffset = 0;
-
-            stream_context_set_params($context, array('notification' =>
-                function ($code, $severity, $msg, $msgCode, $bytesTx, $bytesMax) use (
-                    &$remoteDocument, &$http_response_header, &$httpHeadersOffset
-                ) {
-                    if ($code === STREAM_NOTIFY_MIME_TYPE_IS) {
-                        $remoteDocument->mediaType = $msg;
-                    } elseif ($code === STREAM_NOTIFY_REDIRECTED) {
-                        $remoteDocument->documentUrl = $msg;
-                        $remoteDocument->mediaType = null;
-
-                        $httpHeadersOffset = count($http_response_header);
-                    }
-                }
-            ));
-
-            if (false === ($input = @file_get_contents($url, false, $context))) {
-                throw new JsonLdException(
-                    JsonLdException::LOADING_DOCUMENT_FAILED,
-                    sprintf('Unable to load the remote document "%s".', $url),
-                    $http_response_header
-                );
-            }
-
-            // Extract HTTP Link headers
-            $linkHeaderValues = array();
-            if (is_array($http_response_header)) {
-                for ($i = count($http_response_header) - 1; $i > $httpHeadersOffset; $i--) {
-                    if (0 === substr_compare($http_response_header[$i], 'Link:', 0, 5, true)) {
-                        $value = substr($http_response_header[$i], 5);
-                        $linkHeaderValues[] = $value;
-                    }
-                }
-            }
-
-            $linkHeaderValues = $this->parseContextLinkHeaders($linkHeaderValues, new IRI($url));
-
-            if (count($linkHeaderValues) === 1) {
-                $remoteDocument->contextUrl = reset($linkHeaderValues);
-            } elseif (count($linkHeaderValues) > 1) {
-                throw new JsonLdException(
-                    JsonLdException::MULTIPLE_CONTEXT_LINK_HEADERS,
-                    'Found multiple contexts in HTTP Link headers',
-                    $http_response_header
-                );
-            }
-
-            // If we got a media type, we verify it
-            if ($remoteDocument->mediaType) {
-                // Drop any media type parameters such as profiles
-                if (false !== ($pos = strpos($remoteDocument->mediaType, ';'))) {
-                    $remoteDocument->mediaType = substr($remoteDocument->mediaType, 0, $pos);
-                }
-
-                $remoteDocument->mediaType = trim($remoteDocument->mediaType);
-
-                if ('application/ld+json' === $remoteDocument->mediaType) {
-                    $remoteDocument->contextUrl = null;
-                } elseif (('application/json' !== $remoteDocument->mediaType) &&
-                    (0 !== substr_compare($remoteDocument->mediaType, '+json', -5))) {
-                    throw new JsonLdException(
-                        JsonLdException::LOADING_DOCUMENT_FAILED,
-                        'Invalid media type',
-                        $remoteDocument->mediaType
-                    );
-                }
-            }
-
-            $remoteDocument->document = Processor::parse($input);
-
-            return $remoteDocument;
+            return $this->retrieveRemoteDocument($url);
         }
 
         return new RemoteDocument($url, Processor::parse($input));
+    }
+
+    protected function retrieveRemoteDocument($url)
+    {
+        $remoteDocument = new RemoteDocument($url);
+
+        $streamContextOptions = array(
+          'method'  => 'GET',
+          'header'  => "Accept: application/ld+json, application/json; q=0.9, */*; q=0.1\r\n"
+                       . "User-Agent: lanthaler JsonLD\r\n",
+          'timeout' => Processor::REMOTE_TIMEOUT
+        );
+
+        $context = stream_context_create(array(
+            'http' => $streamContextOptions,
+            'https' => $streamContextOptions
+        ));
+
+        $httpHeadersOffset = 0;
+
+        stream_context_set_params($context, array('notification' =>
+            function ($code, $severity, $msg, $msgCode, $bytesTx, $bytesMax) use (
+                &$remoteDocument, &$http_response_header, &$httpHeadersOffset
+            ) {
+                if ($code === STREAM_NOTIFY_MIME_TYPE_IS) {
+                    $remoteDocument->mediaType = $msg;
+                } elseif ($code === STREAM_NOTIFY_REDIRECTED) {
+                    $remoteDocument->documentUrl = $msg;
+                    $remoteDocument->mediaType = null;
+
+                    $httpHeadersOffset = count($http_response_header);
+                }
+            }
+        ));
+
+        if (false === ($input = @file_get_contents($url, false, $context))) {
+            throw new JsonLdException(
+                JsonLdException::LOADING_DOCUMENT_FAILED,
+                sprintf('Unable to load the remote document "%s".', $url),
+                $http_response_header
+            );
+        }
+
+        // Extract HTTP Link headers
+        $linkHeaderValues = array();
+        if (is_array($http_response_header)) {
+            for ($i = count($http_response_header) - 1; $i > $httpHeadersOffset; $i--) {
+                if (0 === substr_compare($http_response_header[$i], 'Link:', 0, 5, true)) {
+                    $value = substr($http_response_header[$i], 5);
+                    $linkHeaderValues = array_merge($linkHeaderValues, explode(',', $value));
+                }
+            }
+        }
+
+        // Uh-oh - schema.org does no longer supports content negotiation!
+        // This re-routes the request to an appropriate resource as specified by the 'Link' header.
+        $base = new IRI($url);
+
+        foreach ($linkHeaderValues as $value) {
+            if (preg_match("/<(.[^>]+)>;/", $value, $uri)) {
+                $iri = new IRI($uri[1]);
+
+                $link = array('uri' => $iri->isAbsolute() ? $uri[1] : (string) $base->resolve($iri));
+
+                preg_match_all("/;\s?([A-z][^,=]+)=\"(.[^\"]+)\"/", $value, $parameters);
+
+                if (count($parameters) == 3) {
+                    $keys = $parameters[1];
+                    $values = $parameters[2];
+
+                    for ($i=0; $i < count($keys); $i++) {
+                        $link[trim($keys[$i])] = trim($values[$i]);
+                    }
+                }
+
+                if (isset($link['rel']) && isset($link['type']) && ($link['rel'] === 'alternate')) {
+                    switch($link['type']) {
+                        case 'application/ld+json':
+                        case 'application/json':
+                            return $this->retrieveRemoteDocument($link['uri']);
+                            break;
+                    }
+                }
+            }
+        }
+
+        $linkHeaderValues = $this->parseContextLinkHeaders($linkHeaderValues, new IRI($url));
+
+        if (count($linkHeaderValues) === 1) {
+            $remoteDocument->contextUrl = reset($linkHeaderValues);
+        } elseif (count($linkHeaderValues) > 1) {
+            throw new JsonLdException(
+                JsonLdException::MULTIPLE_CONTEXT_LINK_HEADERS,
+                'Found multiple contexts in HTTP Link headers',
+                $http_response_header
+            );
+        }
+
+        // If we got a media type, we verify it
+        if ($remoteDocument->mediaType) {
+            // Drop any media type parameters such as profiles
+            if (false !== ($pos = strpos($remoteDocument->mediaType, ';'))) {
+                $remoteDocument->mediaType = substr($remoteDocument->mediaType, 0, $pos);
+            }
+
+            $remoteDocument->mediaType = trim($remoteDocument->mediaType);
+
+            if ('application/ld+json' === $remoteDocument->mediaType) {
+                $remoteDocument->contextUrl = null;
+            } elseif ('application/octet-stream' === $remoteDocument->mediaType) {
+                $remoteDocument->contextUrl = null;
+            } elseif (('application/json' !== $remoteDocument->mediaType) &&
+                (0 !== substr_compare($remoteDocument->mediaType, '+json', -5))) {
+                throw new JsonLdException(
+                    JsonLdException::LOADING_DOCUMENT_FAILED,
+                    'Invalid media type',
+                    $remoteDocument->mediaType
+                );
+            }
+        }
+
+        $remoteDocument->document = Processor::parse($input);
+
+        return $remoteDocument;
     }
 
     /**

--- a/FileGetContentsLoader.php
+++ b/FileGetContentsLoader.php
@@ -140,8 +140,6 @@ class FileGetContentsLoader implements DocumentLoaderInterface
 
             if ('application/ld+json' === $remoteDocument->mediaType) {
                 $remoteDocument->contextUrl = null;
-            } elseif ('application/octet-stream' === $remoteDocument->mediaType) {
-                $remoteDocument->contextUrl = null;
             } elseif (('application/json' !== $remoteDocument->mediaType) &&
                 (0 !== substr_compare($remoteDocument->mediaType, '+json', -5))) {
                 throw new JsonLdException(

--- a/Test/FileGetContentsLoaderTest.php
+++ b/Test/FileGetContentsLoaderTest.php
@@ -40,9 +40,9 @@ class FileGetContentsLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testParseLinkHeadersExactsValues()
     {
-        $headers = [ 
+        $headers = array(
             '<https://www.google.com>; param1=foo; param2="bar";',
-        ];
+       );
 
         $parsed = $this->loader->parseLinkHeaders($headers, $this->iri);
 
@@ -53,9 +53,9 @@ class FileGetContentsLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testParseLinkHeadersTrimsValues()
     {
-        $headers = [ 
+        $headers = array(
             '< https://www.google.com  >; param1= foo ; param2=" bar ";',
-        ];
+       );
 
         $parsed = $this->loader->parseLinkHeaders($headers, $this->iri);
 
@@ -66,10 +66,10 @@ class FileGetContentsLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testParseLinkHeadersWithMultipleHeaders()
     {
-        $headers = [ 
+        $headers = array(
             '<https://www.google.com>; param1=foo; param2=bar;',
             '<https://www.yahoo.com>; param1=fizz; param2=buzz;',
-        ];
+       );
 
         $parsed = $this->loader->parseLinkHeaders($headers, $this->iri);
 
@@ -78,7 +78,7 @@ class FileGetContentsLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testParseLinkHeadersWithMultipleLinks()
     {
-        $headers = [ '<https://www.google.com>; param1=foo; param2=bar;, <https://www.yahoo.com>; param1=fizz; param2=buzz;' ];
+        $headers = array('<https://www.google.com>; param1=foo; param2=bar;, <https://www.yahoo.com>; param1=fizz; param2=buzz;');
 
         $parsed = $this->loader->parseLinkHeaders($headers, $this->iri);
 
@@ -89,7 +89,7 @@ class FileGetContentsLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testParseLinkHeadersConvertsRelativeLinksToAbsolute()
     {
-        $headers = [ '</foo/bar>;' ];
+        $headers = array('</foo/bar>;');
         $parsed = $this->loader->parseLinkHeaders($headers, $this->iri);
         $this->assertEquals('https://www.google.com/foo/bar', $parsed[0]['uri']);
     }

--- a/Test/FileGetContentsLoaderTest.php
+++ b/Test/FileGetContentsLoaderTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * (c) Markus Lanthaler <mail@markus-lanthaler.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ML\JsonLD\Test;
+
+use ML\IRI\IRI;
+use ML\JsonLD\FileGetContentsLoader;
+
+/**
+ * Test the parsing of a JSON-LD document into a Document.
+ */
+class FileGetContentsLoaderTest extends \PHPUnit_Framework_TestCase
+{
+
+    protected $iri;
+
+    protected $loader;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->iri = new IRI('https://www.google.com');
+        $this->loader = new FileGetContentsLoader;
+    }
+
+    public function tearDown()
+    {
+        unset($iri);
+        unset($this->loader);
+        
+        parent::tearDown();
+    }
+
+    public function testParseLinkHeadersExactsValues()
+    {
+        $headers = [ 
+            '<https://www.google.com>; param1=foo; param2="bar";',
+        ];
+
+        $parsed = $this->loader->parseLinkHeaders($headers, $this->iri);
+
+        $this->assertEquals('https://www.google.com', $parsed[0]['uri']);
+        $this->assertEquals('foo', $parsed[0]['param1']);
+        $this->assertEquals('bar', $parsed[0]['param2']);
+    }
+
+    public function testParseLinkHeadersTrimsValues()
+    {
+        $headers = [ 
+            '< https://www.google.com  >; param1= foo ; param2=" bar ";',
+        ];
+
+        $parsed = $this->loader->parseLinkHeaders($headers, $this->iri);
+
+        $this->assertEquals('https://www.google.com', $parsed[0]['uri']);
+        $this->assertEquals('foo', $parsed[0]['param1']);
+        $this->assertEquals('bar', $parsed[0]['param2']);
+    }
+
+    public function testParseLinkHeadersWithMultipleHeaders()
+    {
+        $headers = [ 
+            '<https://www.google.com>; param1=foo; param2=bar;',
+            '<https://www.yahoo.com>; param1=fizz; param2=buzz;',
+        ];
+
+        $parsed = $this->loader->parseLinkHeaders($headers, $this->iri);
+
+        $this->assertCount(2, $parsed);
+    }
+
+    public function testParseLinkHeadersWithMultipleLinks()
+    {
+        $headers = [ '<https://www.google.com>; param1=foo; param2=bar;, <https://www.yahoo.com>; param1=fizz; param2=buzz;' ];
+
+        $parsed = $this->loader->parseLinkHeaders($headers, $this->iri);
+
+        $this->assertCount(2, $parsed);
+        $this->assertEquals('https://www.google.com', $parsed[0]['uri']);
+        $this->assertEquals('https://www.yahoo.com', $parsed[1]['uri']);
+    }
+
+    public function testParseLinkHeadersConvertsRelativeLinksToAbsolute()
+    {
+        $headers = [ '</foo/bar>;' ];
+        $parsed = $this->loader->parseLinkHeaders($headers, $this->iri);
+        $this->assertEquals('https://www.google.com/foo/bar', $parsed[0]['uri']);
+    }
+
+}

--- a/Test/FileGetContentsLoaderTest.php
+++ b/Test/FileGetContentsLoaderTest.php
@@ -26,7 +26,7 @@ class FileGetContentsLoaderTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->iri = new IRI('https://www.google.com');
+        $this->iri = new IRI('https://www.foobar.com');
         $this->loader = new FileGetContentsLoader;
     }
 
@@ -41,12 +41,12 @@ class FileGetContentsLoaderTest extends \PHPUnit_Framework_TestCase
     public function testParseLinkHeadersExactsValues()
     {
         $headers = array(
-            '<https://www.google.com>; param1=foo; param2="bar";',
+            '<https://www.foobar.com>; param1=foo; param2="bar";',
        );
 
         $parsed = $this->loader->parseLinkHeaders($headers, $this->iri);
 
-        $this->assertEquals('https://www.google.com', $parsed[0]['uri']);
+        $this->assertEquals('https://www.foobar.com', $parsed[0]['uri']);
         $this->assertEquals('foo', $parsed[0]['param1']);
         $this->assertEquals('bar', $parsed[0]['param2']);
     }
@@ -54,12 +54,12 @@ class FileGetContentsLoaderTest extends \PHPUnit_Framework_TestCase
     public function testParseLinkHeadersTrimsValues()
     {
         $headers = array(
-            '< https://www.google.com  >; param1= foo ; param2=" bar ";',
+            '< https://www.foobar.com  >; param1= foo ; param2=" bar ";',
        );
 
         $parsed = $this->loader->parseLinkHeaders($headers, $this->iri);
 
-        $this->assertEquals('https://www.google.com', $parsed[0]['uri']);
+        $this->assertEquals('https://www.foobar.com', $parsed[0]['uri']);
         $this->assertEquals('foo', $parsed[0]['param1']);
         $this->assertEquals('bar', $parsed[0]['param2']);
     }
@@ -67,8 +67,8 @@ class FileGetContentsLoaderTest extends \PHPUnit_Framework_TestCase
     public function testParseLinkHeadersWithMultipleHeaders()
     {
         $headers = array(
-            '<https://www.google.com>; param1=foo; param2=bar;',
-            '<https://www.yahoo.com>; param1=fizz; param2=buzz;',
+            '<https://www.foobar.com>; param1=foo; param2=bar;',
+            '<https://www.fizzbuzz.net>; param1=fizz; param2=buzz;',
        );
 
         $parsed = $this->loader->parseLinkHeaders($headers, $this->iri);
@@ -78,20 +78,20 @@ class FileGetContentsLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testParseLinkHeadersWithMultipleLinks()
     {
-        $headers = array('<https://www.google.com>; param1=foo; param2=bar;, <https://www.yahoo.com>; param1=fizz; param2=buzz;');
+        $headers = array('<https://www.foobar.com>; param1=foo; param2=bar;, <https://www.fizzbuzz.net>; param1=fizz; param2=buzz;');
 
         $parsed = $this->loader->parseLinkHeaders($headers, $this->iri);
 
         $this->assertCount(2, $parsed);
-        $this->assertEquals('https://www.google.com', $parsed[0]['uri']);
-        $this->assertEquals('https://www.yahoo.com', $parsed[1]['uri']);
+        $this->assertEquals('https://www.foobar.com', $parsed[0]['uri']);
+        $this->assertEquals('https://www.fizzbuzz.net', $parsed[1]['uri']);
     }
 
     public function testParseLinkHeadersConvertsRelativeLinksToAbsolute()
     {
         $headers = array('</foo/bar>;');
         $parsed = $this->loader->parseLinkHeaders($headers, $this->iri);
-        $this->assertEquals('https://www.google.com/foo/bar', $parsed[0]['uri']);
+        $this->assertEquals('https://www.foobar.com/foo/bar', $parsed[0]['uri']);
     }
 
 }


### PR DESCRIPTION
schema.org recently dropped support for content negotiation. They instead adopted a Link header, with `rel="alternate"` and `type="application/ld+json"`. This attempts to utilise that header.

See: https://github.com/schemaorg/schemaorg/issues/2578#issuecomment-632227864