### PR TITLE
NQuads.php: made blank node regex more flexible

### DIFF
--- a/NQuads.php
+++ b/NQuads.php
@@ -78,7 +78,7 @@ class NQuads implements QuadSerializerInterface, QuadParserInterface
     {
         // define partial regexes
         $iri = '(?:<([^>]*)>)';
-        $bnode = '(_:(?:[A-Za-z0-9]+))';
+        $bnode = '(_:(?:[A-Za-z0-9\_\.\-]+))';
         $plain = '"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"';
         $datatype = "\\^\\^$iri";
         $language = '(?:@([a-z]+(?:-[a-z0-9]+)*))';

--- a/NQuads.php
+++ b/NQuads.php
@@ -78,7 +78,10 @@ class NQuads implements QuadSerializerInterface, QuadParserInterface
     {
         // define partial regexes
         $iri = '(?:<([^>]*)>)';
-        $bnode = '(_:(?:[A-Za-z0-9\_\.\-]+))';
+
+        // blank node labels based on https://www.w3.org/TR/n-quads/#BNodes
+        $bnode = '(_:(?:[a-z0-9A-Z]{1}[A-Za-z0-9\_\.\-]*[a-zA-Z0-9]{1}))';
+
         $plain = '"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"';
         $datatype = "\\^\\^$iri";
         $language = '(?:@([a-z]+(?:-[a-z0-9]+)*))';

--- a/NQuads.php
+++ b/NQuads.php
@@ -80,9 +80,7 @@ class NQuads implements QuadSerializerInterface, QuadParserInterface
         $iri = '(?:<([^>]*)>)';
 
         // blank node labels based on https://www.w3.org/TR/n-quads/#BNodes
-        $bnode = '(_:(?:';
-        $bnode .= '([a-z0-9A-Z]{1}[A-Za-z0-9\_\.\-]*[a-zA-Z0-9]{1})';
-        $bnode .= '|[a-zA-Z_]))';
+        $bnode = '(_:(?:[A-Za-z0-9_]|[A-Za-z0-9_][A-Za-z0-9_\-.]*[A-Za-z0-9_\-]))';
 
         $plain = '"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"';
         $datatype = "\\^\\^$iri";

--- a/NQuads.php
+++ b/NQuads.php
@@ -80,7 +80,10 @@ class NQuads implements QuadSerializerInterface, QuadParserInterface
         $iri = '(?:<([^>]*)>)';
 
         // blank node labels based on https://www.w3.org/TR/n-quads/#BNodes
-        $bnode = '(_:(?:[a-z0-9A-Z]{1}[A-Za-z0-9\_\.\-]*[a-zA-Z0-9]{1}))';
+        $bnode = '(_:(?:';
+        $bnode .= '([a-z0-9A-Z]{1}';
+        $bnode .= '[A-Za-z0-9\_\.\-\x{00B7}\x{203F}-\x{2400}]*[a-zA-Z0-9{00B7}\x{203F}-\x{2040}]{1})';
+        $bnode .= '|[a-zA-Z_]))';
 
         $plain = '"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"';
         $datatype = "\\^\\^$iri";
@@ -96,7 +99,7 @@ class NQuads implements QuadSerializerInterface, QuadParserInterface
 
         // full regexes
         $eoln = '/(?:(\r\n)|[\n\r])/';
-        $quadRegex = "/^$ws*$subject$property$object$graph?$ws*.$ws*$/";
+        $quadRegex = "/^$ws*$subject$property$object$graph?$ws*.$ws*$/u";
         $ignoreRegex = "/^$ws*(?:$comment)?$/";
 
         // build RDF statements

--- a/NQuads.php
+++ b/NQuads.php
@@ -98,7 +98,7 @@ class NQuads implements QuadSerializerInterface, QuadParserInterface
 
         // full regexes
         $eoln = '/(?:(\r\n)|[\n\r])/';
-        $quadRegex = "/^$ws*$subject$property$object$graph?$ws*.$ws*$/u";
+        $quadRegex = "/^$ws*$subject$property$object$graph?$ws*.$ws*$/";
         $ignoreRegex = "/^$ws*(?:$comment)?$/";
 
         // build RDF statements

--- a/NQuads.php
+++ b/NQuads.php
@@ -81,8 +81,7 @@ class NQuads implements QuadSerializerInterface, QuadParserInterface
 
         // blank node labels based on https://www.w3.org/TR/n-quads/#BNodes
         $bnode = '(_:(?:';
-        $bnode .= '([a-z0-9A-Z]{1}';
-        $bnode .= '[A-Za-z0-9\_\.\-\x{00B7}\x{203F}-\x{2400}]*[a-zA-Z0-9{00B7}\x{203F}-\x{2040}]{1})';
+        $bnode .= '([a-z0-9A-Z]{1}[A-Za-z0-9\_\.\-]*[a-zA-Z0-9]{1})';
         $bnode .= '|[a-zA-Z_]))';
 
         $plain = '"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"';

--- a/Test/NQuadsTest.php
+++ b/Test/NQuadsTest.php
@@ -9,7 +9,6 @@
 
 namespace ML\JsonLD\Test;
 
-use ML\JsonLD\Exception\InvalidQuadException;
 use ML\JsonLD\JsonLD;
 use ML\JsonLD\NQuads;
 

--- a/Test/NQuadsTest.php
+++ b/Test/NQuadsTest.php
@@ -50,56 +50,50 @@ class NQuadsTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Tests parse
+     *
+     * This test checks handling of certain special charaters like _ which can be part of bnode name.
      */
     public function testParseBlankNodes()
     {
         $nquads = new NQuads();
 
         /*
-         * type 1
+         * type 1 - just a letter
          */
-        $blankNodeType1 = '_:b <http://ex/1> "Test" .'.PHP_EOL;
+        $blankNodeType = '_:b <http://ex/1> "Test" .'.PHP_EOL;
 
-        $result = $nquads->parse($blankNodeType1);
+        $result = $nquads->parse($blankNodeType);
         self::assertCount(1, $result);
 
         /*
-         * type 2
+         * type 2 - letter + number
          */
-        $blankNodeType1 = '_:b1 <http://ex/1> "Test" .'.PHP_EOL;
+        $blankNodeType = '_:b1 <http://ex/1> "Test" .'.PHP_EOL;
 
-        $result = $nquads->parse($blankNodeType1);
+        $result = $nquads->parse($blankNodeType);
         self::assertCount(1, $result);
 
         /*
          * type 3 containing _
          */
-        $blankNodeType2 = '_:b_1 <http://ex/1> "Test" .'.PHP_EOL;
+        $blankNodeType = '_:b_1 <http://ex/1> "Test" .'.PHP_EOL;
 
-        $result = $nquads->parse($blankNodeType2);
+        $result = $nquads->parse($blankNodeType);
         self::assertCount(1, $result);
 
         /*
          * type 4: containing .
          */
-        $blankNodeType3 = '_:b.1 <http://ex/1> "Test" .'.PHP_EOL;
+        $blankNodeType = '_:b.1 <http://ex/1> "Test" .'.PHP_EOL;
 
-        $result = $nquads->parse($blankNodeType3);
+        $result = $nquads->parse($blankNodeType);
         self::assertCount(1, $result);
 
         /*
          * type 5: containing -
          */
-        $blankNodeType4 = '_:b-1 <http://ex/1> "Test" .'.PHP_EOL;
-
-        /*
-         * type 6: containing ‿
-         *
-         * https://www.fileformat.info/info/unicode/char/203f/index.htm
-         */
-        $blankNodeType4 = '_:b‿1 <http://ex/1> "Test" .'.PHP_EOL;
-
-        $result = $nquads->parse($blankNodeType4);
+        $blankNodeType = '_:b-1 <http://ex/1> "Test" .'.PHP_EOL;
+        $result = $nquads->parse($blankNodeType);
         self::assertCount(1, $result);
     }
 

--- a/Test/NQuadsTest.php
+++ b/Test/NQuadsTest.php
@@ -58,13 +58,21 @@ class NQuadsTest extends \PHPUnit_Framework_TestCase
         /*
          * type 1
          */
+        $blankNodeType1 = '_:b <http://ex/1> "Test" .'.PHP_EOL;
+
+        $result = $nquads->parse($blankNodeType1);
+        self::assertCount(1, $result);
+
+        /*
+         * type 2
+         */
         $blankNodeType1 = '_:b1 <http://ex/1> "Test" .'.PHP_EOL;
 
         $result = $nquads->parse($blankNodeType1);
         self::assertCount(1, $result);
 
         /*
-         * type 2 (containing _)
+         * type 3 containing _
          */
         $blankNodeType2 = '_:b_1 <http://ex/1> "Test" .'.PHP_EOL;
 
@@ -72,7 +80,7 @@ class NQuadsTest extends \PHPUnit_Framework_TestCase
         self::assertCount(1, $result);
 
         /*
-         * type 3 (containing .)
+         * type 4: containing .
          */
         $blankNodeType3 = '_:b.1 <http://ex/1> "Test" .'.PHP_EOL;
 
@@ -80,9 +88,16 @@ class NQuadsTest extends \PHPUnit_Framework_TestCase
         self::assertCount(1, $result);
 
         /*
-         * type 4 (containing -)
+         * type 5: containing -
          */
         $blankNodeType4 = '_:b-1 <http://ex/1> "Test" .'.PHP_EOL;
+
+        /*
+         * type 6: containing ‿
+         *
+         * https://www.fileformat.info/info/unicode/char/203f/index.htm
+         */
+        $blankNodeType4 = '_:b‿1 <http://ex/1> "Test" .'.PHP_EOL;
 
         $result = $nquads->parse($blankNodeType4);
         self::assertCount(1, $result);

--- a/Test/NQuadsTest.php
+++ b/Test/NQuadsTest.php
@@ -21,7 +21,7 @@ use ML\JsonLD\NQuads;
 class NQuadsTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * Tests the expansion API
+     * Tests that parsing an invalid NQuad file fails
      *
      * @expectedException \ML\JsonLD\Exception\InvalidQuadException
      */
@@ -49,107 +49,59 @@ class NQuadsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Tests parse
-     *
-     * This test checks handling of certain special charaters like _ which can be part of bnode name.
+     * Tests blank node label parsing
      */
     public function testParseBlankNodes()
     {
         $nquads = new NQuads();
 
-        /*
-         * type 1 - just a letter
-         */
-        $blankNodeType = '_:b <http://ex/1> "Test" .'.PHP_EOL;
+        $this->assertNotEmpty($nquads->parse('_:b <http://ex/1> "Test" .'), 'just a letter');
 
-        $result = $nquads->parse($blankNodeType);
-        self::assertCount(1, $result);
+        $this->assertNotEmpty($nquads->parse('_:b1 <http://ex/1> "Test" .'), 'letter and number');
 
-        /*
-         * type 2 - letter + number
-         */
-        $blankNodeType = '_:b1 <http://ex/1> "Test" .'.PHP_EOL;
+        $this->assertNotEmpty($nquads->parse('_:_b1 <http://ex/1> "Test" .'), 'beginning _');
 
-        $result = $nquads->parse($blankNodeType);
-        self::assertCount(1, $result);
+        $this->assertNotEmpty($nquads->parse('_:b_1 <http://ex/1> "Test" .'), 'containing _');
 
-        /*
-         * type 3 containing _
-         */
-        $blankNodeType = '_:b_1 <http://ex/1> "Test" .'.PHP_EOL;
+        $this->assertNotEmpty($nquads->parse('_:b1_ <http://ex/1> "Test" .'), 'ending _');
 
-        $result = $nquads->parse($blankNodeType);
-        self::assertCount(1, $result);
+        $this->assertNotEmpty($nquads->parse('_:b-1 <http://ex/1> "Test" .'), 'containing -');
 
-        /*
-         * type 4: containing .
-         */
-        $blankNodeType = '_:b.1 <http://ex/1> "Test" .'.PHP_EOL;
+        $this->assertNotEmpty($nquads->parse('_:b-1 <http://ex/1> "Test" .'), 'ending -');
 
-        $result = $nquads->parse($blankNodeType);
-        self::assertCount(1, $result);
-
-        /*
-         * type 5: containing -
-         */
-        $blankNodeType = '_:b-1 <http://ex/1> "Test" .'.PHP_EOL;
-        $result = $nquads->parse($blankNodeType);
-        self::assertCount(1, $result);
+        $this->assertNotEmpty($nquads->parse('_:b.1 <http://ex/1> "Test" .'), 'containing .');
     }
 
     /**
-     * Parser has to fail if a - is at the beginning of the blank node label.
+     * Tests that parsing fails for blank node labels beginning with "-"
      *
      * @expectedException \ML\JsonLD\Exception\InvalidQuadException
-     * @see https://www.w3.org/TR/n-quads/#BNodes
      */
-    public function testParseBlankNodesDashAtTheBeginning()
+    public function testParseBlankNodeDashAtTheBeginning()
     {
-        $blankNodeType1 = '_:-b1 <http://ex/1> "Test" .'.PHP_EOL;
-
         $nquads = new NQuads();
-        $nquads->parse($blankNodeType1);
+        $nquads->parse('_:-b1 <http://ex/1> "Test" .');
     }
 
     /**
-     * Parser has to fail if a . is at the beginning of the blank node label.
+     * Tests that parsing fails for blank node labels beginning with "."
      *
      * @expectedException \ML\JsonLD\Exception\InvalidQuadException
-     * @see https://www.w3.org/TR/n-quads/#BNodes
      */
-    public function testParseBlankNodesPointAtTheBeginning()
+    public function testParseBlankNodePeriodAtTheBeginning()
     {
-        $blankNodeType1 = '_:.b1 <http://ex/1> "Test" .'.PHP_EOL;
-
         $nquads = new NQuads();
-        $nquads->parse($blankNodeType1);
+        $nquads->parse('_:.b1 <http://ex/1> "Test" .');
     }
 
     /**
-     * Parser has to fail if a . is at the end of the blank node label.
+     * Tests that parsing fails for blank node labels ending with "."
      *
      * @expectedException \ML\JsonLD\Exception\InvalidQuadException
-     * @see https://www.w3.org/TR/n-quads/#BNodes
      */
-    public function testParseBlankNodesPointAtTheEnd()
+    public function testParseBlankNodePeriodAtTheEnd()
     {
-        $blankNodeType1 = '_:b1. <http://ex/1> "Test" .'.PHP_EOL;
-
         $nquads = new NQuads();
-        $nquads->parse($blankNodeType1);
-    }
-
-    /**
-     * Parser has to fail if a _ is at the beginning of the blank node label.
-     *
-     * @expectedException \ML\JsonLD\Exception\InvalidQuadException
-     * @see https://www.w3.org/TR/n-quads/#BNodes
-     */
-    public function testParseBlankNodesUnderlineAtTheBeginning()
-    {
-        $blankNodeType1 = '_:_b1 <http://ex/1> "Test" .'.PHP_EOL;
-
-        $nquads = new NQuads();
-        $nquads->parse($blankNodeType1);
+        $nquads->parse('_:b1. <http://ex/1> "Test" .');
     }
 }


### PR DESCRIPTION
As far as I understand https://www.w3.org/TR/n-quads/#BNodes, blank node labels in NQuads can include `-`, `.` and `_` too. Specification requires these characters not being at the beginning of the label, but this regex is not structured to check that anyway.