### PR TITLE
Make nullable parameters explicity nullable for PHP 8.4

### DIFF
--- a/Exception/InvalidQuadException.php
+++ b/Exception/InvalidQuadException.php
@@ -32,7 +32,7 @@ class InvalidQuadException extends \RuntimeException
      * @param Quad      $quad     The quad
      * @param null|\Exception $previous The previous exception
      */
-    public function __construct($message, $quad, \Exception $previous = null)
+    public function __construct($message, $quad, ?\Exception $previous = null)
     {
         $this->quad = $quad;
 

--- a/Exception/JsonLdException.php
+++ b/Exception/JsonLdException.php
@@ -247,7 +247,7 @@ class JsonLdException extends \RuntimeException
      * @param null|string     $document The document that triggered the error
      * @param null|\Exception $previous The previous exception
      */
-    public function __construct($code, $message = null, $snippet = null, $document = null, \Exception $previous = null)
+    public function __construct($code, $message = null, $snippet = null, $document = null, ?\Exception $previous = null)
     {
         $this->code = $code;
         $this->document = $document;

--- a/Graph.php
+++ b/Graph.php
@@ -46,7 +46,7 @@ class Graph implements GraphInterface, JsonLdSerializable
      *
      * @param null|DocumentInterface $document The document the graph belongs to.
      */
-    public function __construct(DocumentInterface $document = null)
+    public function __construct(?DocumentInterface $document = null)
     {
         $this->document = $document;
     }

--- a/Processor.php
+++ b/Processor.php
@@ -2232,7 +2232,7 @@ class Processor
      *
      * @return IRI Returns the IRI of the head of the list
      */
-    private function listToRdf(array $entries, array &$quads, IRI $graph = null)
+    private function listToRdf(array $entries, array &$quads, ?IRI $graph = null)
     {
         if (0 === count($entries)) {
             return new IRI(RdfConstants::RDF_NIL);

--- a/Quad.php
+++ b/Quad.php
@@ -56,7 +56,7 @@ class Quad
      *
      * @throws InvalidArgumentException If the object parameter has a wrong type
      */
-    public function __construct(IRI $subject, IRI $property, $object, IRI $graph = null)
+    public function __construct(IRI $subject, IRI $property, $object, ?IRI $graph = null)
     {
         $this->subject = $subject;
         $this->property = $property;
@@ -135,7 +135,7 @@ class Quad
      *
      * @param null|IRI $graph The graph
      */
-    public function setGraph(IRI $graph = null)
+    public function setGraph(?IRI $graph = null)
     {
         $this->graph = $graph;
     }


### PR DESCRIPTION
Implicitly nullable parameter types are deprecated in PHP 8.4

https://www.php.net/manual/it/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter